### PR TITLE
Removes unused "tab" arg in call to kagiImageSearch function

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -68,8 +68,8 @@ chrome.contextMenus.create({
   contexts: ["image"],
 });
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
+chrome.contextMenus.onClicked.addListener((info, _) => {
   if (info.menuItemId === "kagi-image-search") {
-    kagiImageSearch(info, tab);
+    kagiImageSearch(info);
   }
 });


### PR DESCRIPTION
Just spotted this one whilst developing a separate branch. 

"tab" is part of callback, and then passed as 2nd arg to kagiImageSearch.

kagiImageSearch only takes 1 arg though