### PR TITLE
Fixes persistent context menu creation error "cannot create duplicate item" in service worker

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kagi Search",
-  "version": "1.2.2.2",
+  "version": "1.2.2.3",
   "description": "Set Kagi as your default search engine while also preserving your session in private browsing. Remember to enable 'Allow Incognito'.",
   "background": {
     "service_worker": "service_worker.js",

--- a/service_worker.js
+++ b/service_worker.js
@@ -4,6 +4,11 @@ let extensionToken = undefined; // use process memory to hold the token
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
     chrome.tabs.create({ url: kagiBaseUrl });
+    chrome.contextMenus.create({
+      id: "kagi-image-search",
+      title: "Kagi Image Search",
+      contexts: ["image"],
+    });
   }
 });
 
@@ -61,12 +66,6 @@ function kagiImageSearch(info) {
     url: `${kagiBaseUrl}images?q=${imageUrl}&reverse=reference`,
   });
 }
-
-chrome.contextMenus.create({
-  id: "kagi-image-search",
-  title: "Kagi Image Search",
-  contexts: ["image"],
-});
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "kagi-image-search") {


### PR DESCRIPTION
Due to the contextMenu creation code living at the top level of the service worker, that code runs every time the service worker is invoked. 

I noticed it due to my other PR causing the service worker to run every time a new tab is opened :P its a very persistent and annoying error, but it doesn't break anything. 

Its a simple fix, this contextMenu creation code should be housed within the installation event callback, specifically when the event is INSTALL, so it only runs on install.